### PR TITLE
アセンブリ定義ファイルを変更

### DIFF
--- a/Assets/Project/AssemblyDifinitions/View/View.asmdef
+++ b/Assets/Project/AssemblyDifinitions/View/View.asmdef
@@ -5,7 +5,9 @@
         "GUID:560b04d1a97f54a4e82edc0cbbb69285",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:029c1c1b674aaae47a6841a0b89ad80e",
-        "GUID:1a6be227346ac8745a511432f2258344"
+        "GUID:1a6be227346ac8745a511432f2258344",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:dc47925d1a5fa2946bdd37746b2b5d48"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
TextMeshProをViewで使うため、アセンブリ定義ファイルを変更した。
![image](https://github.com/user-attachments/assets/d74904af-a95e-49f6-b931-f269fd507e8f)
