### PR TITLE
UserModelのインスタンスが一貫していないバグを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# This .gitignore file should be placed at the root of your Unity project directory
+﻿# This .gitignore file should be placed at the root of your Unity project directory
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
 #
@@ -122,3 +122,4 @@ x86_64/
 
 # local user settings
 Assets/Project/**/UserData.json
+Assets/Project/**/UserData.json.meta

--- a/Assets/Project/Scenes/Title/Scripts/Repository/ModelRepository/TitleModelRepository.cs
+++ b/Assets/Project/Scenes/Title/Scripts/Repository/ModelRepository/TitleModelRepository.cs
@@ -6,8 +6,8 @@ namespace Project.Scenes.Title.Scripts.Repository.ModelRepository
 {
     public class TitleModelRepository : ModelRepositoryBase
     {
-        public static TitleModelRepository Instance => new();
-        
+        public static TitleModelRepository Instance { get; } = new();
+
         TitleModel titleModel;
 
         public TitleModelRepository()

--- a/Assets/Project/Scripts/Model/UserModel.cs
+++ b/Assets/Project/Scripts/Model/UserModel.cs
@@ -8,8 +8,7 @@ namespace Project.Scripts.Model
     public class UserModel : ModelBase
     {
         UserData UserData { get; set; }
-        public static UserModel Instance => new();
-        
+
         public int ClearedStageNumber => UserData.clearedStageNumber;
 
         readonly string saveDirectoryPath;

--- a/Assets/Project/Scripts/Repository/ModelRepository/CharacterModelRepository.cs
+++ b/Assets/Project/Scripts/Repository/ModelRepository/CharacterModelRepository.cs
@@ -7,9 +7,9 @@ namespace Project.Scripts.Repository.ModelRepository
 {
     public class CharacterModelRepository : ModelRepositoryBase
     {
-        public static CharacterModelRepository instance = new();
-        
-        readonly List<CharacterData> characterData = new();
+        public static CharacterModelRepository Instance { get; } = new();
+
+        readonly List<CharacterData> characterData;
         readonly List<CharacterModel> characterModels = new();
 
         public CharacterModelRepository()

--- a/Assets/Project/Scripts/Repository/ModelRepository/ModelRepositoryBase.cs
+++ b/Assets/Project/Scripts/Repository/ModelRepository/ModelRepositoryBase.cs
@@ -11,6 +11,7 @@ namespace Project.Scripts.Repository.ModelRepository
         protected string dataName = "";
         protected string DataAddress 
             => ZString.Format("{0}/{1}.asset", GamePath.DataStorepath, dataName);
+
         protected UserModel UserModel => UserModelRepository.Instance.Get();
 
         protected T LoadDataObject<T>()

--- a/Assets/Project/Scripts/Repository/ModelRepository/UserModelRepository.cs
+++ b/Assets/Project/Scripts/Repository/ModelRepository/UserModelRepository.cs
@@ -4,8 +4,7 @@ namespace Project.Scripts.Repository.ModelRepository
 {
     public class UserModelRepository
     {
-        public static UserModelRepository Instance => new();
-
+        public static UserModelRepository Instance { get; } = new();
 
         UserModel userModel = new();
 


### PR DESCRIPTION
## 概要

UserModelRepositoryが以下になっていた.
```cs
public static UserModelRepository Instance => new();
```

これだと`Instance`は`new()`のaliasに過ぎず、Instanceにアクセスするたびに`new()`が呼ばれ、別のインスタンスを取得してしまう.
要は以下みたいな感じ

```cs
public static UserModelRepository GetInstance()
{
    return new();
}
```

よって以下に修正した.

```cs
public static UserModelRepository Instance { get; } = new();
```

要はこれは以下と同値.

```cs
private static UserModelRepository instance = new();

public static UserModelRepository GetInstance()
{
    return instance;
}
```

なんならコンパイルの途中段階で実際こんな感じになるらしい
これで一貫したインスタンスが取得できる.
また、上記の形で`static Instance`の記法を上記で統一するようにリファクタした.

## 修正後のログ

<img width="959" height="340" alt="image" src="https://github.com/user-attachments/assets/3b9ac060-bb84-4b17-9351-900142af2722" />

## 備考

関係ないcommitでごめんだけど、`UserData.json.meta`がignoreされてなかったのでignoreしました
