### PR TITLE
シナリオシーン関連のバグ修正

### DIFF
--- a/Assets/Project/Commons/Debugger.meta
+++ b/Assets/Project/Commons/Debugger.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1faa77ec6fde58448d818c22330311d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Prefabs.meta
+++ b/Assets/Project/Commons/Debugger/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a05e0bef58f940b43b03c60a584d8d62
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Prefabs/DebuggerObject.prefab
+++ b/Assets/Project/Commons/Debugger/Prefabs/DebuggerObject.prefab
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3206900960360694429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3241323120525968627}
+  - component: {fileID: 6055463501492457358}
+  m_Layer: 0
+  m_Name: DebuggerObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3241323120525968627
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3206900960360694429}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6055463501492457358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3206900960360694429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4769ebf607798840a4e505abe81f26f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageNumber: 1
+  situation: 0

--- a/Assets/Project/Commons/Debugger/Prefabs/DebuggerObject.prefab.meta
+++ b/Assets/Project/Commons/Debugger/Prefabs/DebuggerObject.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3a7569f3381cd4c4d9f3dc790a805b27
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts.meta
+++ b/Assets/Project/Commons/Debugger/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 651df550088ed184d9fc2d8f66fa5e9c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/Model.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/Model.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f8d23f582ba0d84f980575d480d0497
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/Model/Model.asmref
+++ b/Assets/Project/Commons/Debugger/Scripts/Model/Model.asmref
@@ -1,0 +1,3 @@
+{
+                        "reference": "Model"
+                    }

--- a/Assets/Project/Commons/Debugger/Scripts/Model/Model.asmref.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/Model/Model.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 225920a0c64da704b838f5ab3fe17918
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08912620ef0fa644a935ab7005681649
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs
@@ -1,0 +1,21 @@
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+using Project.Scripts.Model;
+using Project.Scripts.Repository.ModelRepository;
+using UnityEngine;
+
+namespace Project.Commons.Debugger.Scripts.Presenter
+{
+    public class DebugRuntimeModelInitializer : MonoBehaviour
+    {
+        [SerializeField, Min(1)] int stageNumber = 1;
+        [SerializeField] BattleSituation situation = BattleSituation.Way;
+
+        void Awake()
+        {
+            var runtimeModel = RuntimeModelRepository.Instance.Get();
+            runtimeModel.SetForDebug(stageNumber, situation);
+            Debug.Log($"[DebugRuntimeModelInitializer] Stage={stageNumber}, Situation={situation} に設定しました");
+        }
+    }
+}
+#endif

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs
@@ -13,6 +13,11 @@ namespace Project.Commons.Debugger.Scripts.Presenter
         void Awake()
         {
             var runtimeModel = RuntimeModelRepository.Instance.Get();
+            if (runtimeModel.IsInGame)
+            {
+                Debug.Log("[DebugRuntimeModelInitializer] RuntimeModel は既にゲーム中のためデバッグ初期化をスキップしました");
+                return;
+            }
             runtimeModel.SetForDebug(stageNumber, situation);
             Debug.Log($"[DebugRuntimeModelInitializer] Stage={stageNumber}, Situation={situation} に設定しました");
         }

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter/DebugRuntimeModelInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4769ebf607798840a4e505abe81f26f

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter/Presenter.asmref
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter/Presenter.asmref
@@ -1,0 +1,3 @@
+{
+                        "reference": "Presenter"
+                    }

--- a/Assets/Project/Commons/Debugger/Scripts/Presenter/Presenter.asmref.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/Presenter/Presenter.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 40389868c07808b4ab51f5af14bdf8b4
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/View.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/View.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f8638dbfd4555b4c88e7eb80a329cdf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Commons/Debugger/Scripts/View/View.asmref
+++ b/Assets/Project/Commons/Debugger/Scripts/View/View.asmref
@@ -1,0 +1,3 @@
+{
+                        "reference": "View"
+                    }

--- a/Assets/Project/Commons/Debugger/Scripts/View/View.asmref.meta
+++ b/Assets/Project/Commons/Debugger/Scripts/View/View.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f2f9eae15573f2043ad68adfaa1e195e
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/DataStore/StageData.asset
+++ b/Assets/Project/DataStore/StageData.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
     charaStillAddress: Azuma
     title: "\u5317\u8FB0\u3092\u8FFD\u3063\u3066"
     waySequenceAddress: Assets/Project/DataStore/Stage2/Way/Stage2Way.asset
-    bossSequenceAddress: Assets/Project/DataStore/Stage2/Way/Stage2Boss.asset
+    bossSequenceAddress: Assets/Project/DataStore/Stage2/Boss/Stage2Boss.asset
   - id: 3
     stageNumber: 3
     charaStillAddress: Tatsumi

--- a/Assets/Project/Scenes/Battle.unity
+++ b/Assets/Project/Scenes/Battle.unity
@@ -119,6 +119,63 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &937993894
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3206900960360694429, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_Name
+      value: DebuggerObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
 --- !u!1 &1432705673
 GameObject:
   m_ObjectHideFlags: 0
@@ -522,7 +579,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   phaseStateMachine: {fileID: 2011392385}
-  initialStageNumber: 1
 --- !u!114 &2011392385
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -650,3 +706,4 @@ SceneRoots:
   - {fileID: 1992721158}
   - {fileID: 2011392386}
   - {fileID: 2072124215}
+  - {fileID: 937993894}

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/BattlePhaseStateMachine.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/BattlePhaseStateMachine.cs
@@ -31,7 +31,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             }
 
             Debug.Log($"[BattlePhaseStateMachine] PlaySequence called for {sequence.Situation}", this);
-            Stop();
+            Stop(sequenceToKeep: sequence);
             activeSequence = sequence;
             activeSequence.Reset();
 
@@ -104,7 +104,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             playableDirector.Play();
         }
 
-        public void Stop()
+        public void Stop(BattleSequenceModel sequenceToKeep = null)
         {
             Debug.Log($"[BattlePhaseStateMachine] Stop called, activeSequence: {activeSequence?.Situation}", this);
             exitSubscription?.Dispose();
@@ -118,7 +118,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             activePhase?.Exit();
             activePhase = null;
 
-            if (activeSequence != null)
+            if (activeSequence != null && activeSequence != sequenceToKeep)
             {
                 DisposeSequence(activeSequence);
                 activeSequence = null;

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
@@ -6,6 +6,7 @@ using Project.Scenes.Battle.Scripts.Model;
 using Project.Scripts.Model;
 using Project.Scripts.Repository.ModelRepository;
 using Project.Scenes.Battle.Scripts.Repository.ModelRepository;
+using Project.Scenes.Battle.Scripts.Presenter.Entity;
 
 namespace Project.Scenes.Battle.Scripts.Presenter
 {
@@ -21,6 +22,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
         BattleSequenceModel waySequence;
         BattleSequenceModel bossSequence;
         Action pendingScenarioCallback;
+        PlayerEntityPresenter playerPresenter;
 
         public IObservable<Unit> OnBattleCompleted => battleCompleted;
 
@@ -51,6 +53,13 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             {
                 Debug.LogError("StageModel could not be resolved.", this);
                 return;
+            }
+
+            // PlayerEntityPresenterを取得
+            playerPresenter = FindFirstObjectByType<PlayerEntityPresenter>();
+            if (playerPresenter == null)
+            {
+                Debug.LogWarning("[BattleScenePresenter] PlayerEntityPresenter not found in scene.", this);
             }
 
             waySequence = LoadSequence(stageModel.WaySequenceAddress);
@@ -124,6 +133,9 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             // ScenarioIdは不要、ScenarioModelRepositoryがRuntimeModelから自動決定
             Debug.Log($"[BattleScenePresenter] TransitionToScenario called", this);
 
+            // シナリオ中は攻撃を禁止
+            playerPresenter?.UnsubscribeToAttackInput();
+
             // シナリオ完了後のコールバックを保存
             pendingScenarioCallback = onCompleteOrSkip;
 
@@ -157,6 +169,10 @@ namespace Project.Scenes.Battle.Scripts.Presenter
         void OnScenarioCompleted()
         {
             Debug.Log("[BattleScenePresenter] Scenario completed, invoking callback.", this);
+
+            // シナリオ完了後は攻撃を再開
+            playerPresenter?.SubscribeToAttackInput();
+
             pendingScenarioCallback?.Invoke();
             pendingScenarioCallback = null;
         }

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
@@ -190,6 +190,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             // 次のステージのシーケンスをロード
             stageModel = nextStageModel;
             waySequence = LoadSequence(stageModel.WaySequenceAddress);
+            bossSequence = LoadSequence(stageModel.BossSequenceAddress);
 
             // 道中シーケンスを開始
             if (waySequence != null)

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
@@ -23,6 +23,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
         BattleSequenceModel bossSequence;
         Action pendingScenarioCallback;
         PlayerEntityPresenter playerPresenter;
+        bool isSceneLoadedHandlerRegistered = false;
 
         public IObservable<Unit> OnBattleCompleted => battleCompleted;
 
@@ -134,13 +135,17 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             Debug.Log($"[BattleScenePresenter] TransitionToScenario called", this);
 
             // シナリオ中は攻撃を禁止
-            playerPresenter?.UnsubscribeToAttackInput();
+            playerPresenter?.UnsubscribeFromAttackInput();
 
             // シナリオ完了後のコールバックを保存
             pendingScenarioCallback = onCompleteOrSkip;
 
             // シーンロード完了を待ってからイベントを購読
-            SceneManager.sceneLoaded += OnScenarioSceneLoaded;
+            if (!isSceneLoadedHandlerRegistered)
+            {
+                SceneManager.sceneLoaded += OnScenarioSceneLoaded;
+                isSceneLoadedHandlerRegistered = true;
+            }
             SceneManager.LoadScene(SceneRouterModel.Scenario, LoadSceneMode.Additive);
         }
 
@@ -149,16 +154,22 @@ namespace Project.Scenes.Battle.Scripts.Presenter
             if (scene.name != SceneRouterModel.Scenario) return;
 
             Debug.Log($"[BattleScenePresenter] Scenario scene loaded", this);
-            SceneManager.sceneLoaded -= OnScenarioSceneLoaded;
+            
+            // ハンドラを解除
+            if (isSceneLoadedHandlerRegistered)
+            {
+                SceneManager.sceneLoaded -= OnScenarioSceneLoaded;
+                isSceneLoadedHandlerRegistered = false;
+            }
 
             // ScenarioScenePresenterを見つけてイベントを購読
             var scenarioPresenter = FindFirstObjectByType<Project.Scenes.Scenario.Scripts.Presenter.ScenarioScenePresenter>();
             if (scenarioPresenter != null)
             {
                 scenarioPresenter.OnScenarioCompleted
-                    .Take(1) // 1回だけ実行
-                    .Subscribe(_ => OnScenarioCompleted())
-                    .AddTo(disposables);
+                                 .Take(1) // 1回だけ実行
+                                 .Subscribe(_ => OnScenarioCompleted())
+                                 .AddTo(disposables);
             }
             else
             {
@@ -221,7 +232,14 @@ namespace Project.Scenes.Battle.Scripts.Presenter
         }
 
         void OnDestroy()
-        {
+        {   
+            // 登録されているハンドラを確実に解除
+            if (isSceneLoadedHandlerRegistered)
+            {
+                SceneManager.sceneLoaded -= OnScenarioSceneLoaded;
+                isSceneLoadedHandlerRegistered = false;
+            }
+            
             disposables.Dispose();
             battleCompleted.Dispose();
             phaseStateMachine?.Stop();

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/BattleScenePresenter.cs
@@ -12,7 +12,6 @@ namespace Project.Scenes.Battle.Scripts.Presenter
     public class BattleScenePresenter : MonoBehaviour
     {
         [SerializeField] BattlePhaseStateMachine phaseStateMachine;
-        [SerializeField, Min(1)] int initialStageNumber = 1;
 
         readonly BattleSequenceModelRepository sequenceModelRepository = new();
         readonly Subject<Unit> battleCompleted = new();
@@ -75,7 +74,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter
         StageModel ResolveStageModel()
         {
             var runtimeModel = RuntimeModelRepository.Instance.Get();
-            var stageNumber = runtimeModel.CurrentStageNumber < initialStageNumber ? initialStageNumber : runtimeModel.CurrentStageNumber;
+            var stageNumber = runtimeModel.CurrentStageNumber < 1 ? 1 : runtimeModel.CurrentStageNumber;
 
             try
             {

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/Entity/PlayerEntityPresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/Entity/PlayerEntityPresenter.cs
@@ -80,6 +80,11 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
 
         public void SubscribeToAttackInput()
         {
+            // 既存の入力購読が残っている場合は一度破棄してから再購読する
+            if (inputDisposables != null && !inputDisposables.IsDisposed)
+            {
+                inputDisposables.Dispose();
+            }
             inputDisposables = new CompositeDisposable();
 
             // 攻撃ボタンをイベントで処理
@@ -111,7 +116,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
                 .AddTo(inputDisposables);
         }
 
-        public void UnsubscribeToAttackInput()
+        public void UnsubscribeFromAttackInput()
         {
             inputDisposables?.Dispose();
             inputDisposables = new CompositeDisposable();

--- a/Assets/Project/Scenes/Battle/Scripts/Presenter/Entity/PlayerEntityPresenter.cs
+++ b/Assets/Project/Scenes/Battle/Scripts/Presenter/Entity/PlayerEntityPresenter.cs
@@ -39,6 +39,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
         float lastShootTime;
         Vector2 currentMoveInput;
         readonly CompositeDisposable disposables = new();
+        CompositeDisposable inputDisposables;
 
         public PlayerEntityModel Model => model;
         public IObservable<Unit> OnDeath => model?.OnDeath;
@@ -54,7 +55,8 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
         void Start()
         {
             BindModelToView();
-            SubscribeToInput();
+            SubscribeToMoveInput();
+            SubscribeToAttackInput();
         }
 
         void BindModelToView()
@@ -64,7 +66,7 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
                 .AddTo(disposables);
         }
 
-        void SubscribeToInput()
+        void SubscribeToMoveInput()
         {
             // 移動入力を保持（Updateで使用）
             MessageBroker.Default.Receive<PlayerMoveMessage>()
@@ -74,13 +76,18 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
                     currentMoveInput = msg.value;
                 })
                 .AddTo(disposables);
+        }
+
+        public void SubscribeToAttackInput()
+        {
+            inputDisposables = new CompositeDisposable();
 
             // 攻撃ボタンをイベントで処理
             MessageBroker.Default.Receive<PlayerAttackMessage>()
                 .Where(_ => !model.IsSneaking.Value)
                 .Where(_ => Time.time >= lastShootTime + shootCooldown)
                 .Subscribe(_ => FireNormalShot())
-                .AddTo(disposables);
+                .AddTo(inputDisposables);
 
             // スニークボタンの押下/解除
             MessageBroker.Default.Receive<PlayerCrouchMessage>()
@@ -101,7 +108,13 @@ namespace Project.Scenes.Battle.Scripts.Presenter.Entity
                         model.SetSneaking(false);
                     }
                 })
-                .AddTo(disposables);
+                .AddTo(inputDisposables);
+        }
+
+        public void UnsubscribeToAttackInput()
+        {
+            inputDisposables?.Dispose();
+            inputDisposables = new CompositeDisposable();
         }
 
         void Update()

--- a/Assets/Project/Scenes/Scenario.unity
+++ b/Assets/Project/Scenes/Scenario.unity
@@ -456,8 +456,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1893086799
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -667,8 +667,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -1893086799
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1081,7 +1081,7 @@ Canvas:
   m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
+  m_SortingLayerID: -1893086799
   m_SortingOrder: 0
   m_TargetDisplay: 0
 --- !u!224 &2069735978

--- a/Assets/Project/Scenes/Scenario.unity
+++ b/Assets/Project/Scenes/Scenario.unity
@@ -809,6 +809,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1979815997
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3206900960360694429, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_Name
+      value: DebuggerObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241323120525968627, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3a7569f3381cd4c4d9f3dc790a805b27, type: 3}
 --- !u!1 &2040640892
 GameObject:
   m_ObjectHideFlags: 0
@@ -1060,3 +1117,4 @@ SceneRoots:
   - {fileID: 1223816786}
   - {fileID: 909658331}
   - {fileID: 2069735978}
+  - {fileID: 1979815997}

--- a/Assets/Project/Scripts/Model/RuntimeModel.cs
+++ b/Assets/Project/Scripts/Model/RuntimeModel.cs
@@ -42,5 +42,13 @@
             CurrentStageNumber = -1;
             CurrentSituation = BattleSituation.Way;
         }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        public void SetForDebug(int stageNumber, BattleSituation situation)
+        {
+            CurrentStageNumber = stageNumber;
+            CurrentSituation = situation;
+        }
+#endif
     }
 }

--- a/Assets/Project/Scripts/Repository/AssetRepository/FaceAssetRepository.cs
+++ b/Assets/Project/Scripts/Repository/AssetRepository/FaceAssetRepository.cs
@@ -27,11 +27,10 @@ namespace Project.Scripts.Repository.AssetRepository
                 sprite =>
                 {
                     var spriteName = sprite.name;
-                    // スプライト名の形式: {characterName}_{expressionType}_Face_0
+                    // スプライト名の形式: {characterName}_{expressionType}_Face
                     // characterNameの長さ + 1（アンダースコア）を開始位置とする
                     var charNameLength = characterName.Length + 1;
-                    var faceIndex = spriteName.LastIndexOf("_Face_");
-                    
+                    var faceIndex = spriteName.LastIndexOf("_Face");
                     if (faceIndex > charNameLength)
                     {
                         // expressionTypeを抽出: charNameLengthからfaceIndexまでの部分


### PR DESCRIPTION
対応したもの

* シナリオシーンとの連携
  * シナリオ中に弾出せないようにする
  * 立ち絵のレイヤーを前にする(背景←立ち絵←テキスト)
  * DisposedなSubjectにアクセスしてしまうエラー（１面→２面と連続してシナリオを見ると発生）
  * フォントがけばけばしてる
    * アセットの文字間隔狭すぎ？
* シナリオシーン単体でテストできるようにする
  * 起動時にRuntimeModelのステージ数を設定するデバッグ用スクリプト的な