### PR TITLE
ボタンの連打対応

### DIFF
--- a/Assets/Project/Commons/UI/Scripts/Presenter/GameOverModalPresenter.cs
+++ b/Assets/Project/Commons/UI/Scripts/Presenter/GameOverModalPresenter.cs
@@ -1,6 +1,7 @@
 using System;
 using Cysharp.Threading.Tasks;
 using Project.Commons.UI.Scripts.View;
+using Project.Scripts.Extensions;
 using Project.Scripts.Model;
 using Project.Scripts.Presenter;
 using Project.Scripts.Repository.ModelRepository;
@@ -47,7 +48,7 @@ namespace Project.Commons.UI.Scripts.Presenter
                     pauseEvent = null;
                 });
             }).AddTo(this);
-            gameOverModalView.OnPressedTitle.Subscribe(_ => LoadTitle().Forget()).AddTo(this);
+            gameOverModalView.OnPressedTitle.SubscribeBlocking(_ => LoadTitle()).AddTo(this);
 
             if (!IsOpen)
             {
@@ -78,7 +79,7 @@ namespace Project.Commons.UI.Scripts.Presenter
             onRetryRequested.OnNext(Unit.Default);
         }
 
-        async UniTaskVoid LoadTitle()
+        async UniTask LoadTitle()
         {
             IsOpen = false;
             Time.timeScale = 1f;

--- a/Assets/Project/Scenes/StageList/Scripts/Presenter/StageListScenePresenter.cs
+++ b/Assets/Project/Scenes/StageList/Scripts/Presenter/StageListScenePresenter.cs
@@ -43,9 +43,9 @@ namespace Project.Scenes.StageList.Scripts.Presenter
 
             ShowCharaImage(0);
             stageCardListView.OnButtonChanged.Subscribe(ShowCharaImage);
-            stageCardListView.OnButtonPressed.Subscribe(i => LoadBattleScene(i).Forget());
+            stageCardListView.OnButtonPressed.SubscribeBlocking(LoadBattleScene).AddTo(this);
             MessageBroker.Default.Receive<UICancelMessage>()
-                .Subscribe(_ => BackToTitle().Forget())
+                .SubscribeBlocking(_ => BackToTitle())
                 .AddTo(this);
         }
 

--- a/Assets/Project/Scenes/Title/Scripts/Presenter/TitleScenePresenter.cs
+++ b/Assets/Project/Scenes/Title/Scripts/Presenter/TitleScenePresenter.cs
@@ -32,11 +32,11 @@ namespace Project.Scenes.Title.Scripts.Presenter
             titleMenuView.InitStart();
 
             // titleMenuView.OnPressedStartMain.Subscribe(_ => { StartMain(_).Forget(); });
-            titleMenuView.OnPressedStart.Subscribe(x =>
+            titleMenuView.OnPressedStart.SubscribeBlocking(async x =>
             {
                 soundManager.PlaySEAsync(SeType.Click).Forget();
-                StartGame(x).Forget();
-            });
+                await StartGame(x);
+            }).AddTo(this);
             titleMenuView.OnPressedOption.Subscribe(async _ =>
             {
                 soundManager.PlaySEAsync(SeType.Click).Forget();

--- a/Assets/Project/Scripts/Extensions/Extensions.asmdef
+++ b/Assets/Project/Scripts/Extensions/Extensions.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:560b04d1a97f54a4e82edc0cbbb69285"
+        "GUID:560b04d1a97f54a4e82edc0cbbb69285",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Project/Scripts/Extensions/ObservableExtensions.cs
+++ b/Assets/Project/Scripts/Extensions/ObservableExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using Cysharp.Threading.Tasks;
+using UniRx;
+
+namespace Project.Scripts.Extensions
+{
+    public static class ObservableExtensions
+    {
+        /// <summary>
+        /// asyncActionの実行中に発火したイベントを無視し、ボタンの二重クリック等による多重起動を防ぐ。
+        /// </summary>
+        public static IDisposable SubscribeBlocking<T>(this IObservable<T> source, Func<T, UniTask> asyncAction)
+        {
+            var isExecuting = false;
+
+            return source.Subscribe(x =>
+            {
+                if (isExecuting) return;
+                isExecuting = true;
+                Execute(x).Forget();
+            });
+
+            async UniTaskVoid Execute(T value)
+            {
+                try
+                {
+                    await asyncAction(value);
+                }
+                finally
+                {
+                    isExecuting = false;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Project/Scripts/Extensions/ObservableExtensions.cs.meta
+++ b/Assets/Project/Scripts/Extensions/ObservableExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c914787abf74bf4f873e0671a67ee7c


### PR DESCRIPTION
## 概要
ボタンを押してから処理が完了するまでの間に再度クリックされ、二重に処理が起動してしまう不具合を修正。

## 原因
`ButtonBase.OnPressed` は素のRxストリームで、クリックごとに無条件で発火する。シーン遷移など `await` を伴う非同期処理を呼ぶハンドラには、処理中の再入力を防ぐ仕組みが無かった（タイトル→ステージ選択への遷移は特にガードが無かった）。

## 対応
非同期処理の完了まで再発火を無視する `IObservable<T>.SubscribeBlocking(Func<T, UniTask>)` 拡張メソッドを追加し、`await` を挟むシーン遷移系のハンドラに適用。

- `Assets/Project/Scripts/Extensions/ObservableExtensions.cs`（新規）
- `TitleScenePresenter`: ステージ選択への遷移
- `StageListScenePresenter`: バトルシーンへの遷移／タイトルへの戻り
- `GameOverModalPresenter`: タイトルへの戻り（`LoadTitle` を `UniTaskVoid` → `UniTask` に変更）

なお、Modalの開閉処理は `gameObject.SetActive(false)` 等が同期的に即時実行されるため、クリックと入力遮断の間に隙間が無く対象外とした。

## 動作確認

済